### PR TITLE
Add --xsize=SIZE option to exclude files of size < SIZE

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,12 @@ who contributed the patch or idea appears first, followed by
 those who've otherwise worked on that item. For a list of 
 contributors names and identifiers please see the CONTRIBUTORS file.
 
+Changes from 1.51-jody4 to 1.51-jody4-jkl1 [JKL]
+
+- added `--xsize=SIZE' option: exclude files of size < SIZE
+- updated Makefile: `PREFIX = /usr/local'
+- updated README: Usage to reflect curent parameters
+
 Changes from 1.51 to 1.51-jody2 [JLB]
 
 - Switched to C99

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,6 +10,7 @@ on their contributions. Names are listed in alphabetical order.
       DJ Chrysalis 		(j@4u.net)
  [JB] Jean-Baptiste         	()
 [JLB] Jody Lee Bruchon		(jody@jodybruchon.com)
+[JKL] Jan Klabacka		(jan.klabacka@gmail.com)
  [KK] Kresimir Kukulj 		(madmax@pc-hrvoje.srce.hr)
  [LB] Laurent Bonnaud		(Laurent.Bonnaud@iut2.upmf-grenoble.fr)
  [LM] Luca Montecchiani 	(m.luca@iname.com)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # determination of the actual installation directories.
 # Suggested values are "/usr/local", "/usr", "/pkgs/fdupes-$(VERSION)"
 #
-PREFIX = /usr
+PREFIX = /usr/local
 
 #
 # Certain platforms do not support long options (command line options).

--- a/README
+++ b/README
@@ -8,27 +8,41 @@ Usage
 --------------------------------------------------------------------
 Usage: fdupes [options] DIRECTORY...
 
- -r --recurse     	for every directory given follow subdirectories
-                  	encountered within
- -R --recurse:    	for each directory given after this option follow
-                  	subdirectories encountered within
- -s --symlinks    	follow symlinks
- -H --hardlinks   	normally, when two or more files point to the same
-                  	disk area they are treated as non-duplicates; this
-                  	option will change this behavior
- -n --noempty     	exclude zero-length files from consideration
- -f --omitfirst   	omit the first file in each set of matches
- -1 --sameline    	list each set of matches on a single line
- -S --size        	show size of duplicate files
- -q --quiet       	hide progress indicator
- -d --delete      	prompt user for files to preserve and delete all
-                  	others; important: under particular circumstances,
-                  	data may be lost when using this option together
-                  	with -s or --symlinks, or when specifying a
-                  	particular directory more than once; refer to the
-                  	fdupes documentation for additional information
- -v --version     	display fdupes version
- -h --help        	display this help message
+ -r --recurse          for every directory given follow subdirectories
+                       encountered within
+ -R --recurse:         for each directory given after this option follow
+                       subdirectories encountered within (note the ':' at
+                       the end of the option, manpage for more details)
+ -s --symlinks         follow symlinks
+ -H --hardlinks        normally, when two or more files point to the same
+                       disk area they are treated as non-duplicates; this
+                       option will change this behavior
+ -L --linkhard         hardlink duplicate files to the first file in
+                       each set of duplicates without prompting the user
+ -n --noempty          exclude zero-length files from consideration
+ -x --xsize=SIZE       exclude files of size < SIZE from consideration; the
+                       SIZE argument accepts 'k', 'M' and 'G' unit suffix
+ -A --nohidden         exclude hidden files from consideration
+ -f --omitfirst        omit the first file in each set of matches
+ -1 --sameline         list each set of matches on a single line
+ -S --size             show size of duplicate files
+ -m --summarize        summarize dupe information
+ -q --quiet            hide progress indicator
+ -d --delete           prompt user for files to preserve and delete all
+                       others; important: under particular circumstances,
+                       data may be lost when using this option together
+                       with -s or --symlinks, or when specifying a
+                       particular directory more than once; refer to the
+                       fdupes documentation for additional information
+ -N --noprompt         together with --delete, preserve the first file in
+                       each set of duplicates and delete the rest without
+                       prompting the user
+ -p --permissions      don't consider files with different owner/group or
+                       permission bits as duplicates
+ -o --order=BY         select sort order for output, linking and deleting; by
+                       mtime (BY='time'; default) or filename (BY='filename')
+ -v --version          display fdupes version
+ -h --help             display this help message
 
 Unless -1 or --sameline is specified, duplicate files are listed 
 together in groups, each file displayed on a separate line. The

--- a/VERSION
+++ b/VERSION
@@ -2,4 +2,4 @@
 # VERSION determines the program's version number.
 #
 
-VERSION = 1.51-jody4
+VERSION = 1.51-jody4-jkl1

--- a/fdupes.1
+++ b/fdupes.1
@@ -36,6 +36,17 @@ treated as non-duplicates; this option will change this behavior
 .B -n --noempty
 exclude zero-length files from consideration
 .TP
+.B -x --xsize=SIZE
+exclude files of size < SIZE from consideration; following suffixes can be used:
+.RS
+.IP `k'
+for kilobytes (units of 1024 bytes)
+.IP `M'
+for Megabytes (units of 1024 x 1024 bytes)
+.IP `G'
+for Gigabytes (units of 1024 x 1024 x 1024 bytes)
+.RE
+.TP
 .B -f --omitfirst
 omit the first file in each set of matches
 .TP

--- a/fdupes.c
+++ b/fdupes.c
@@ -72,6 +72,7 @@
 #define F_EXCLUDEHIDDEN     0x1000
 #define F_PERMISSIONS       0x2000
 #define F_HARDLINKFILES     0x4000
+#define F_EXCLUDESIZE       0x8000
 
 typedef enum {
   ORDER_TIME = 0,
@@ -81,6 +82,7 @@ typedef enum {
 const char *program_name;
 
 uint_fast16_t flags = 0;
+unsigned long long int excludesize = 0;
 
 #define CHUNK_SIZE 8192
 #define INPUT_SIZE 256
@@ -276,6 +278,12 @@ static int grokdir(const char *dir, file_t ** const filelistp)
       }
 
       if (!S_ISDIR(info.st_mode) && info.st_size == 0 && ISFLAG(flags, F_EXCLUDEEMPTY)) {
+	free(newfile->d_name);
+	free(newfile);
+	continue;
+      }
+
+      if (!S_ISDIR(info.st_mode) && ISFLAG(flags, F_EXCLUDESIZE) && info.st_size < excludesize) {
 	free(newfile->d_name);
 	free(newfile);
 	continue;
@@ -928,6 +936,8 @@ static void help_text()
   printf("                  \teach set of duplicates without prompting the user\n");
 #endif
   printf(" -n --noempty     \texclude zero-length files from consideration\n");
+  printf(" -x --xsize=SIZE  \texclude files of size < SIZE from consideration; the\n");
+  printf("                  \tSIZE argument accepts 'k', 'M' and 'G' unit suffix\n");
   printf(" -A --nohidden    \texclude hidden files from consideration\n");
   printf(" -f --omitfirst   \tomit the first file in each set of matches\n");
   printf(" -1 --sameline    \tlist each set of matches on a single line\n");
@@ -969,6 +979,7 @@ int main(int argc, char **argv) {
   int firstrecurse;
   ordertype_t ordertype = ORDER_TIME;
   int delay = 0;
+  char *endptr;
 
 #ifndef OMIT_GETOPT_LONG
   static struct option long_options[] =
@@ -989,6 +1000,7 @@ int main(int argc, char **argv) {
     { "linkhard", 0, 0, 'L' },
 #endif
     { "noempty", 0, 0, 'n' },
+    { "xsize", 1, 0, 'x' },
     { "nohidden", 0, 0, 'A' },
     { "delete", 0, 0, 'd' },
     { "version", 0, 0, 'v' },
@@ -1011,12 +1023,12 @@ int main(int argc, char **argv) {
 
   while ((opt = GETOPT(argc, argv,
 #ifndef ON_WINDOWS
-  "frRq1SsHLnAdvhNmpo:"
+  "frRq1SsHLnx:AdvhNmpo:"
 #else
   #ifdef NO_SYMLINKS
-  "frRq1SnAdvhNmpo:"
+  "frRq1Snx:AdvhNmpo:"
   #else
-  "frRq1SsnAdvhNmpo:"
+  "frRq1Ssnx:AdvhNmpo:"
   #endif /* NO_SYMLINKS */
 #endif /* ON_WINDOWS */
 #ifndef OMIT_GETOPT_LONG
@@ -1057,6 +1069,30 @@ int main(int argc, char **argv) {
 #endif
     case 'n':
       SETFLAG(flags, F_EXCLUDEEMPTY);
+      break;
+    case 'x':
+      SETFLAG(flags, F_EXCLUDESIZE);
+      excludesize = strtoull(optarg, &endptr, 0);
+      switch (*endptr) {
+        case 'k':
+          excludesize = excludesize * 1024;
+          endptr++;
+          break;
+        case 'M':
+          excludesize = excludesize * 1024 * 1024;
+          endptr++;
+          break;
+        case 'G':
+          excludesize = excludesize * 1024 * 1024 * 1024;
+          endptr++;
+          break;
+        default:
+          break;
+      }
+      if (*endptr != '\0') {
+        errormsg("invalid value for --xsize: '%s'\n", optarg);
+        exit(1);
+      }
       break;
     case 'A':
       SETFLAG(flags, F_EXCLUDEHIDDEN);


### PR DESCRIPTION
> _Would you create a pull request so I can pull this into the main fdupes-jody repo?_

Thanks for the interest.

##### The feature:
- `--xsize=SIZE` option: exclude files of size < SIZE

##### Little bit of housekeeping:

- README: _Usage_ section now consistent with `--help`

##### Potential incompatibilities/collisions:
- Makefile: `PREFIX = /usr/local` (now consistent with INSTALL, but perhaps against your intention?)
- VERSION: somehow weird (meant to set apart version in my fork while not interfering with your versioning)

To the latter two, pls. either cherry-pick or let me know how to modify these further.